### PR TITLE
feat(library name):

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,19 @@
 ### HTTP React Fetcher
+----
 
+######
+
+**This package have been renamed to `http-react` (see  [here](https://npmjs.org/package/http-react)). For stability, `http-react-fetcher` has not been deprecated but may be in the near future.**
+
+**You can install the new library by running:**
+
+```bash
+yarn add http-react
+# Or
+npm install http-react
+```
+
+---
 React hooks for data fetching
 
 <p align="center">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react-fetcher",
-  "version": "2.3.9",
+  "version": "2.4.0",
   "description": "React hooks for data fetching",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Changed library name for a shorter one:  `http-react-fetcher`  --> `http-react`
Old library will not be deprecated (yet)