### PR TITLE
feat(Suspense):

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,20 +20,5 @@ Or
 yarn add http-react
 ```
 
-### Browser
-
-With React
-
-```html
-<script src="https://unpkg.com/http-react@2.2.9/dist/http-react.min.js"></script>
-```
-
-
-Without React
-
-```html
-<script src="https://unpkg.com/http-react@2.2.9/dist/vanilla.min.js"></script>
-```
-
 [Getting started](https://http-react.netlify.app)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -239,6 +239,10 @@ export declare type FetcherConfigType<FetchDataType = any, BodyType = any> = {
      */
     retryOnReconnect?: boolean;
     /**
+     * If using inside a `<Suspense>`
+     */
+    suspense?: boolean;
+    /**
      * Request configuration
      */
     config?: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "React hooks for data fetching",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Added support for Suspense.

Example:

```jsx
import { Suspense } from 'react'
import { useFetch } from 'http-react'

function Profile() {
  const { data } = useFetch('/api/profile', {
    suspense: true // If we don't pass anything, this will work as a normal component would
  })

  return (
    <div>
      <p>Email: {data.email}</p>
    </div>
  )
}

export default function App() {
  return (
    <div>
      <h2>Welcome</h2>
      <Suspense fallback={<p>Loading profile...</p>}>
        <Profile />
      </Suspense>
    </div>
  )
}
```