### PR TITLE
feat(Suspense):

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-/// <reference types="react" />
+import * as React from 'react';
 declare type CustomResponse<T> = Omit<Response, 'json'> & {
     json(): Promise<T>;
 };
@@ -66,6 +66,13 @@ reqConfig?: {
     code: number;
     res: CustomResponse<R>;
 }>;
+/**
+ * This is a wrapper around `Suspense`. It will render `fallback` during the first render and then leave the rendering to `Suspense`. If you are not using SSR, you should continue using the `Suspense` component.
+ */
+export declare function SSRSuspense({ fallback, children }: {
+    fallback: React.ReactNode;
+    children: React.ReactNode;
+}): JSX.Element;
 /**
  *
  * @param str The target string

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "React hooks for data fetching",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Added `SSRSuspense` component for when using Suspense with SSR. It's a wrapper around the `Suspense` component.

Example:

```jsx
import { SSRSuspense, useFetch } from "http-react"

function Profile() {
  const { data } = useFetch("/api/profile", {
    id: "profile",
    suspense: true,
  })

  return (
    <section>
      <p>Name: {data?.name}</p>
      <p>Email: {data?.email}</p>
    </section>
  )
}

export default function Home() {
  return (
    <main>
      <h2>Perfil</h2>
      <SSRSuspense fallback={<p>Loading profile</p>}>
        <h2>El perfil</h2>
        <Profile />
      </SSRSuspense>
    </main>
  )
}

```