### PR TITLE
Feat usefetch fetch api

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react",
-  "version": "2.5.4",
+  "version": "2.5.5",
   "description": "React hooks for data fetching",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "description": "React hooks for data fetching",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -41,28 +41,13 @@ export function FetcherConfig(props: FetcherContextType) {
 
   const previousConfig = useHRFContext()
 
-  const { cache = defaultCache } = previousConfig
-
-  let base = !isDefined(baseUrl)
-    ? !isDefined(previousConfig.baseUrl)
-      ? ''
-      : previousConfig.baseUrl
-    : baseUrl
+  const { cacheProvider = defaultCache } = previousConfig
 
   for (let defaultKey in defaults) {
-    const { id } = defaults[defaultKey]
-    const resolvedKey = serialize(
-      isDefined(id)
-        ? {
-            idString: serialize(id)
-          }
-        : {
-            uri: `${base}${defaultKey}`,
-            config: {
-              method: defaults[defaultKey]?.config?.method
-            }
-          }
-    )
+    const { id = defaultKey } = defaults[defaultKey]
+    const resolvedKey = serialize({
+      idString: serialize(id)
+    })
 
     if (isDefined(id)) {
       if (!isDefined(valuesMemory[resolvedKey])) {
@@ -73,8 +58,8 @@ export function FetcherConfig(props: FetcherContextType) {
       }
     }
 
-    if (!isDefined(cache.get(resolvedKey))) {
-      cache.set(resolvedKey, defaults[defaultKey]?.value)
+    if (!isDefined(cacheProvider.get(resolvedKey))) {
+      cacheProvider.set(resolvedKey, defaults[defaultKey]?.value)
     }
   }
 

--- a/src/hooks/others.ts
+++ b/src/hooks/others.ts
@@ -78,13 +78,13 @@ export function useFetcherData<ResponseType = any, VT = any>(
       : ResponseType
   ) => void
 ) {
-  const { cache = defaultCache } = useHRFContext()
+  const { cacheProvider = defaultCache } = useHRFContext()
 
   const defaultsKey = serialize({
     idString: serialize(id)
   })
 
-  const def = cache.get(defaultsKey)
+  const def = cacheProvider.get(defaultsKey)
 
   const { data } = useFetcher<typeof id>({
     default: def,

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -65,6 +65,8 @@ export const fetcherDefaults: any = {}
 
 export const cacheForMutation: any = {}
 
+export const runningMutate: any = {}
+
 export const urls: {
   [k: string]: {
     realUrl: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,7 +26,7 @@ export type FetcherContextType = {
        * Default value for this request
        */
       value?: any
-      config?: any
+      method?: HTTP_METHODS
     }
   }
   suspense?: any[]
@@ -44,7 +44,7 @@ export type FetcherContextType = {
   onOffline?: () => void
   online?: boolean
   retryOnReconnect?: boolean
-  cache?: CacheStoreType
+  cacheProvider?: CacheStoreType
   revalidateOnMount?: boolean
 }
 
@@ -66,36 +66,24 @@ export type RequestWithBody = <R = any, BodyType = any>(
   /**
    * The request configuration
    */
-  reqConfig?: {
+  reqConfig?: Omit<RequestInit, 'body'> & {
+    body?: BodyType
     /**
      * Default value
      */
     default?: R
     /**
-     * Other configuration
+     * Request query
      */
-    config?: {
-      /**
-       * Request query
-       */
-      query?: any
-      /**
-       * The function that formats the body
-       */
-      formatBody?(b: BodyType): any
-      /**
-       * Request headers
-       */
-      headers?: any
-      /**
-       * Request params (like Express)
-       */
-      params?: any
-      /**
-       * The request body
-       */
-      body?: BodyType
-    }
+    query?: any
+    /**
+     * The function that formats the body
+     */
+    formatBody?(b: BodyType): any
+    /**
+     * Request params (like Express)
+     */
+    params?: any
     /**
      * The function that returns the resolved data
      */
@@ -108,6 +96,7 @@ export type RequestWithBody = <R = any, BodyType = any>(
      * A function that will run when the request completes succesfuly
      */
     onResolve?(data: R, res: CustomResponse<R>): void
+    cacheProvider?: CacheStoreType
   }
 ) => Promise<{
   error: any
@@ -133,7 +122,11 @@ export type ImperativeFetcher = {
   unlink: RequestWithBody
 }
 
-export type FetcherConfigType<FetchDataType = any, BodyType = any> = {
+export type FetcherConfigType<FetchDataType = any, BodyType = any> = Omit<
+  RequestInit,
+  'body'
+> & {
+  body?: BodyType
   /**
    * Any serializable id. This is optional.
    */
@@ -171,7 +164,7 @@ export type FetcherConfigType<FetchDataType = any, BodyType = any> = {
   /**
    * Override the cache for this specific request
    */
-  cache?: CacheStoreType
+  cacheProvider?: CacheStoreType
   /**
    * Function to run when data is mutated
    */
@@ -265,13 +258,14 @@ export type FetcherConfigType<FetchDataType = any, BodyType = any> = {
    * Request method
    */
   method?: HTTP_METHODS
-  headers?: Headers | object
+  /**
+   * URL search params
+   */
   query?: any
   /**
    * URL params
    */
   params?: any
-  body?: BodyType
   /**
    * Customize how body is formated for the request. By default it will be sent in JSON format
    * but you can set it to false if for example, you are sending a `FormData`

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -86,7 +86,7 @@ export function setURLParams(str: string = '', $params: any = {}) {
   return (
     str
       .split('/')
-      .map(($segment) => {
+      .map($segment => {
         const [segment] = $segment.split('?')
         if (segment.startsWith('[') && segment.endsWith(']')) {
           const paramName = segment.replace(/\[|\]/g, '')
@@ -142,7 +142,7 @@ export function createRequestFn(
     const rawUrl = setURLParams(url, params)
 
     const reqQueryString = Object.keys(query)
-      .map((q) => [q, query[q]].join('='))
+      .map(q => [q, query[q]].join('='))
       .join('&')
 
     const reqConfig = {
@@ -227,7 +227,7 @@ export const createImperativeFetcher = (ctx: FetcherContextType) => {
 
   return Object.fromEntries(
     new Map(
-      keys.map((k) => [
+      keys.map(k => [
         k.toLowerCase(),
         (url, config = {}) =>
           (useFetcher as any)[k.toLowerCase()](
@@ -244,7 +244,7 @@ export const createImperativeFetcher = (ctx: FetcherContextType) => {
  */
 export function revalidate(id: any | any[]) {
   if (Array.isArray(id)) {
-    id.map((reqId) => {
+    id.map(reqId => {
       if (isDefined(reqId)) {
         const key = serialize(reqId)
 
@@ -311,7 +311,7 @@ export function queryProvider<R>(
       /**
        * The caching mechanism
        */
-      cache?: CacheStoreType
+      cacheProvider?: CacheStoreType
     }
   }
 ) {
@@ -347,10 +347,10 @@ export function queryProvider<R>(
 
     const { config = {} } = providerConfig || {}
 
-    const { cache, ...others } = config
+    const { cacheProvider, ...others } = config
 
     const g = useGql(queries[queryName] as any, {
-      cache: config?.cache,
+      cacheProvider: config?.cacheProvider,
       graphqlPath: isDefined(thisDefaults?.graphqlPath)
         ? thisDefaults?.graphqlPath
         : undefined,

--- a/test/json/config.test.ts
+++ b/test/json/config.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook, waitFor } from '@testing-library/react'
-import { useFetcher } from '../../'
+import { useFetch } from '../../'
 import mocks from '../mocks'
 
 test('Config is modified by AtomicState provider', async () => {
@@ -13,7 +13,7 @@ test('Config is modified by AtomicState provider', async () => {
 
   await act(async () => {
     const { result } = renderHook(() =>
-      useFetcher({
+      useFetch({
         url: '',
         default: [],
         baseUrl: 'test-url',

--- a/test/json/delete.test.ts
+++ b/test/json/delete.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react'
-import { useFetcher } from '../../'
+import { useFetch } from '../../'
 import mocks from '../mocks'
 
 test('DELETE data in JSON', async () => {
@@ -11,7 +11,7 @@ test('DELETE data in JSON', async () => {
 
   await act(async () => {
     const { result } = renderHook(() =>
-      useFetcher({
+      useFetch({
         url: '',
         default: [],
         method: 'DELETE',

--- a/test/json/get.test.ts
+++ b/test/json/get.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react'
-import { useFetcher } from '../../'
+import { useFetch } from '../../'
 import mocks from '../mocks'
 
 test('GET data in JSON', async () => {
@@ -10,7 +10,7 @@ test('GET data in JSON', async () => {
   )
 
   await act(async () => {
-    const { result } = renderHook(useFetcher, {
+    const { result } = renderHook(useFetch, {
       initialProps: {
         url: ''
       }

--- a/test/json/post.test.ts
+++ b/test/json/post.test.ts
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react'
-import { useFetcher } from '../../'
+import { useFetch } from '../../'
 import mocks from '../mocks'
 
 test('POST data in JSON', async () => {
@@ -11,7 +11,7 @@ test('POST data in JSON', async () => {
 
   await act(async () => {
     const { result } = renderHook(() =>
-      useFetcher({
+      useFetch({
         url: '',
         method: 'POST',
         body: {


### PR DESCRIPTION
## Feat: `useFetch` extends the native `Fetch` API
`useFetch` now extends the Fetch API. This gives more control over the request when calling `useFetch`, so things like: `mode`, `integrity`, `keepalive`, `cache`, `referrer`, etc, can be passed in the request config. This helps keep the `useFetch` hook configuration as similar as possible to the native Fetch API while still adding helpful features that can make data fetching in React more declarative and efficient.

### Important changes:
- Because the `RequestInit` of `fetch` already has a reserverd `cache` property, the `cache` property in `useFetch` was changed to `cacheProvider`. The same applies to the `queryProvider` (for graphql) function.
- If `id` is not passed in the request config, a default id will be created using the `method` and the `url` of the request (a `URI`). This doesn't apply to graphl because the id is generated using the query passed.

For example:

```jsx
import useFetch from 'http-react'

function App() {
  useFetch('/save-work', {
    method: 'POST'
  })

  return <div></div>
}
```

If `id` is not passed, the default id of that request will be  `GET /save-work`

This is important because it will allow you to read the information about a request from any component/hook, so you could do:
```js
const { data, loading } = useFetchIf('GET /save-work')
```

It will also make it easier to invalidate a request from anywhere (not necesarily a component) using `revalidate`

```js
import { revalidate } from 'http-react'

function forceRevalidation(){
  revalidate('GET /save-work')
}
```

The [Documentation](https://http-react.netlify.app/) will be updated soon

I'm open to suggestions and feedback!