### PR TITLE
chore(useFetch deps):

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react",
-  "version": "2.5.6",
+  "version": "2.5.8",
   "description": "React hooks for data fetching",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -3,14 +3,14 @@ import { useEffect, useState, Suspense } from 'react'
 
 import {
   defaultCache,
-  FetcherContext,
+  FetchContext,
   fetcherDefaults,
   useHRFContext,
   valuesMemory,
   willSuspend
 } from '../internal'
 
-import { FetcherContextType } from '../types'
+import { FetchContextType } from '../types'
 
 import { isDefined, serialize } from '../utils'
 
@@ -36,8 +36,8 @@ export function SSRSuspense({
   ) as JSX.Element
 }
 
-export function FetcherConfig(props: FetcherContextType) {
-  const { children, defaults = {}, baseUrl, suspense = [] } = props
+export function FetchConfig(props: FetchContextType) {
+  const { children, defaults = {}, suspense = [] } = props
 
   const previousConfig = useHRFContext()
 
@@ -76,12 +76,13 @@ export function FetcherConfig(props: FetcherContextType) {
     headers: {
       ...previousConfig.headers,
       ...props.headers
-    }
+    },
+    children: undefined
   }
 
   return (
-    <FetcherContext.Provider value={mergedConfig}>
+    <FetchContext.Provider value={mergedConfig}>
       {children}
-    </FetcherContext.Provider>
+    </FetchContext.Provider>
   )
 }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,15 +1,15 @@
-export { useFetcher as useFetch } from "./use-fetcher"
+export { useFetch } from './use-fetch'
 
 export {
-  useFetcherLoading as useLoading,
-  useFetcherConfig as useConfig,
-  useFetcherData as useData,
-  useFetcherCode as useCode,
-  useFetcherError as useError,
-  useFetcherMutate as useMutate,
-  useFetcherId as useFetchId,
-  useFetcherBlob as useBlob,
-  useFetcherText as useText,
+  useFetchLoading as useLoading,
+  useFetchConfig as useConfig,
+  useFetchData as useData,
+  useFetchCode as useCode,
+  useFetchError as useError,
+  useFetchMutate as useMutate,
+  useFetchId as useFetchId,
+  useFetchBlob as useBlob,
+  useFetchText as useText,
   useGET,
   useDELETE,
   useHEAD,
@@ -22,5 +22,5 @@ export {
   useUNLINK,
   useResolve,
   useGql,
-  useImperative,
-} from "./others"
+  useImperative
+} from './others'

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,11 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export type { CacheStoreType, FetcherInit } from './types'
+export type { CacheStoreType, FetchInit } from './types'
 
-import { useFetch } from './hooks'
-
-export default useFetch
+export { useFetch as default } from './hooks'
 
 export {
   useFetch,
@@ -38,12 +36,13 @@ export {
   useResolve
 } from './hooks'
 
-export { FetcherConfig, SSRSuspense } from './components'
+export { FetchConfig, SSRSuspense } from './components'
 
 export {
   gql,
   setURLParams,
   queryProvider,
   mutateData,
-  revalidate
+  revalidate,
+  hasBaseUrl
 } from './utils'

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -1,6 +1,6 @@
 import { createContext, useContext } from 'react'
 
-import { CacheStoreType, FetcherContextType } from '../types'
+import { CacheStoreType, FetchContextType } from '../types'
 import {
   ATTEMPTS,
   ATTEMPT_INTERVAL,
@@ -46,7 +46,11 @@ export const resolvedRequests: any = {}
 
 export const resolvedHookCalls: any = {}
 
+export const resolvedOnErrorCalls: any = {}
+
 export const abortControllers: any = {}
+
+export const canDebounce: any = {}
 
 /**
  * Request with errors
@@ -131,9 +135,8 @@ const defaultContextVaue = {
   revalidateOnMount: REVALIDATE_ON_MOUNT
 }
 
-export const FetcherContext =
-  createContext<FetcherContextType>(defaultContextVaue)
+export const FetchContext = createContext<FetchContextType>(defaultContextVaue)
 
 export function useHRFContext() {
-  return useContext(FetcherContext)
+  return useContext(FetchContext)
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,7 +10,7 @@ export type HTTP_METHODS =
   | 'LINK'
   | 'UNLINK'
 
-export type FetcherContextType = {
+export type FetchContextType = {
   headers?: any
   baseUrl?: string
   /**
@@ -46,7 +46,7 @@ export type FetcherContextType = {
   retryOnReconnect?: boolean
   cacheProvider?: CacheStoreType
   revalidateOnMount?: boolean
-}
+} & Omit<RequestInit, 'body'>
 
 export type CacheStoreType = {
   get(k?: any): any
@@ -101,15 +101,15 @@ export type RequestWithBody = <R = any, BodyType = any>(
 ) => Promise<{
   error: any
   data: R
-  config: any
+  config: RequestInit
   code: number
   res: CustomResponse<R>
 }>
 
 /**
- * An imperative version of the `useFetcher`
+ * An imperative version of the `useFetch` hook
  */
-export type ImperativeFetcher = {
+export type ImperativeFetch = {
   get: RequestWithBody
   delete: RequestWithBody
   head: RequestWithBody
@@ -122,7 +122,7 @@ export type ImperativeFetcher = {
   unlink: RequestWithBody
 }
 
-export type FetcherConfigType<FetchDataType = any, BodyType = any> = Omit<
+export type FetchConfigType<FetchDataType = any, BodyType = any> = Omit<
   RequestInit,
   'body'
 > & {
@@ -160,7 +160,7 @@ export type FetcherConfigType<FetchDataType = any, BodyType = any> = Omit<
   /**
    * Function to run when request is resolved succesfuly
    */
-  onResolve?: (data: FetchDataType, req?: Response) => void
+  onResolve?: (data: FetchDataType, res?: Response) => void
   /**
    * Override the cache for this specific request
    */
@@ -171,9 +171,9 @@ export type FetcherConfigType<FetchDataType = any, BodyType = any> = Omit<
   onMutate?: (
     data: FetchDataType,
     /**
-     * An imperative version of `useFetcher`
+     * An imperative version of `useFetche`
      */
-    fetcher: ImperativeFetcher
+    fetcher: ImperativeFetch
   ) => void
   /**
    * Function to run when props change
@@ -184,9 +184,9 @@ export type FetcherConfigType<FetchDataType = any, BodyType = any> = Omit<
       (reason?: any): void
       (): void
     }
-    fetcher: ImperativeFetcher
-    props: FetcherConfigTypeNoUrl<FetchDataType, BodyType>
-    previousProps: FetcherConfigTypeNoUrl<FetchDataType, BodyType>
+    fetcher: ImperativeFetch
+    props: FetchConfigTypeNoUrl<FetchDataType, BodyType>
+    previousProps: FetchConfigTypeNoUrl<FetchDataType, BodyType>
   }) => void
   /**
    * Function to run when the request fails
@@ -273,20 +273,19 @@ export type FetcherConfigType<FetchDataType = any, BodyType = any> = Omit<
    * (the last one is the default behaviour so in that case you can ignore it)
    */
   formatBody?: boolean | ((b: BodyType) => any)
+  /**
+   * The time to wait before revalidation after props change
+   */
+  debounce?: number
 }
 
 // If first argument is a string
-export type FetcherConfigTypeNoUrl<FetchDataType = any, BodyType = any> = Omit<
-  FetcherConfigType<FetchDataType, BodyType>,
+export type FetchConfigTypeNoUrl<FetchDataType = any, BodyType = any> = Omit<
+  FetchConfigType<FetchDataType, BodyType>,
   'url'
 >
 
 /**
- * Create a configuration object to use in a 'useFetcher' call
+ * Create a configuration object to use in a 'useFetche' call
  */
-export type FetcherInit<FDT = any, BT = any> = FetcherConfigTypeNoUrl<
-  FDT,
-  BT
-> & {
-  url?: string
-}
+export type FetchInit<FDT = any, BT = any> = FetchConfigType<FDT, BT>


### PR DESCRIPTION
- Ignores the `children` property passed in context to prevent the `Cannot convert circular structure to JSON` error
- Prevents other fetcher calls from polluting the top context by fixing buggy `Object.assign` call in which the context object was passed as the first arg