### PR TITLE
feat(responseTime):

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react",
-  "version": "2.5.8",
+  "version": "2.5.9",
   "description": "React hooks for data fetching",
   "main": "dist/index.js",
   "scripts": {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -10,6 +10,7 @@ export {
   useFetchId as useFetchId,
   useFetchBlob as useBlob,
   useFetchText as useText,
+  useFetchResponseTime as useResponseTime,
   useGET,
   useDELETE,
   useHEAD,

--- a/src/hooks/others.ts
+++ b/src/hooks/others.ts
@@ -15,6 +15,7 @@ import {
   hasErrors,
   isPending,
   lastResponses,
+  requestResponseTimes,
   requestsProvider,
   runningRequests,
   useHRFContext
@@ -415,6 +416,12 @@ export function useFetchText<FetchDataType = string, BodyType = any>(
       return text
     }
   })
+}
+
+export function useFetchResponseTime(id: any) {
+  return useFetch({
+    id
+  }).responseTime
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,8 @@ export {
   useUNLINK,
   useGql,
   useImperative,
-  useResolve
+  useResolve,
+  useResponseTime
 } from './hooks'
 
 export { FetchConfig, SSRSuspense } from './components'

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -52,6 +52,10 @@ export const abortControllers: any = {}
 
 export const canDebounce: any = {}
 
+export const requestInitialTimes: any = {}
+
+export const requestResponseTimes: any = {}
+
 /**
  * Request with errors
  */

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,6 +6,7 @@ import {
   cacheForMutation,
   defaultCache,
   previousConfig,
+  requestInitialTimes,
   requestsProvider,
   runningMutate,
   valuesMemory
@@ -80,7 +81,7 @@ export function setURLParams(str: string = '', $params: any = {}) {
   return (
     str
       .split('/')
-      .map($segment => {
+      .map(($segment) => {
         const [segment] = $segment.split('?')
         if (segment.startsWith('[') && segment.endsWith(']')) {
           const paramName = segment.replace(/\[|\]/g, '')
@@ -109,6 +110,13 @@ export function setURLParams(str: string = '', $params: any = {}) {
   )
 }
 
+export function getTimePassed(key: any) {
+  return (
+    Date.now() -
+    (isDefined(requestInitialTimes[key]) ? requestInitialTimes[key] : 0)
+  )
+}
+
 /**
  * Creates a new request function. This is for usage with fetcher and fetcher.extend
  */
@@ -133,7 +141,7 @@ export function createRequestFn(
     const rawUrl = setURLParams(url, params)
 
     const reqQueryString = Object.keys(query)
-      .map(q => [q, query[q]].join('='))
+      .map((q) => [q, query[q]].join('='))
       .join('&')
 
     const reqConfig = {
@@ -231,7 +239,7 @@ export const createImperativeFetch = (ctx: FetchContextType) => {
 
   return Object.fromEntries(
     new Map(
-      keys.map(k => [
+      keys.map((k) => [
         k.toLowerCase(),
         (url, config = {}) =>
           (useFetch as any)[k.toLowerCase()](
@@ -251,7 +259,7 @@ export const createImperativeFetch = (ctx: FetchContextType) => {
  */
 export function revalidate(id: any | any[]) {
   if (Array.isArray(id)) {
-    id.map(reqId => {
+    id.map((reqId) => {
       if (isDefined(reqId)) {
         const key = serialize(reqId)
 


### PR DESCRIPTION
Adds `useResponseTime` hook that returns the time (in miliseconds) it took to complete a request. Example:

```jsx
import { useFetch } from 'http-react'

function App() {
  const { data, loading, error, responseTime } = useFetch('/api/profile')

  if (loading) return <p>Loading</p>

  if (error) return <p>Error</p>

  return (
    <div>
      <p>Email: {data?.email}</p>
      <small>Completed in {responseTime} miliseconds</small>
    </div>
  )
}
```

If you wanted to get the response time from another component/hook, you can do so by using the `useResponseTime` hook, which takes the `id` of the request as argument. Because we did not pass an id to the `useFetch` call above, we can use the method and the url instead:


```jsx
import { useResponseTime } from 'http-react'

function ResponseTimeBanner() {
  const responseTime = useResponseTime('GET /api/profile')

  return <small>Completed in {responseTime} miliseconds</small>
}
```