### PR TITLE
feat(HttpReact):

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react",
-  "version": "2.6.6",
+  "version": "2.6.7",
   "description": "React hooks for data fetching",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,3 +1,4 @@
+'use client'
 import * as React from 'react'
 import { useEffect, useState, Suspense } from 'react'
 
@@ -12,7 +13,7 @@ import {
 
 import { FetchContextType } from '../types'
 
-import { isDefined, serialize } from '../utils'
+import { isDefined, serialize } from '../utils/shared'
 
 /**
  * This is a wrapper around `Suspense`. It will render `fallback` during the first render and then leave the rendering to `Suspense`. If you are not using SSR, you should continue using the `Suspense` component.

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
+'use client'
 export { useFetch } from './use-fetch'
 
 export {

--- a/src/hooks/others.ts
+++ b/src/hooks/others.ts
@@ -1,3 +1,4 @@
+'use client'
 import * as React from 'react'
 import { useEffect } from 'react'
 
@@ -23,12 +24,9 @@ import {
 
 import { useFetch } from './use-fetch'
 
-import {
-  createImperativeFetch,
-  isDefined,
-  isFunction,
-  serialize
-} from '../utils'
+import { createImperativeFetch } from '../utils'
+
+import { isDefined, isFunction, serialize } from '../utils/shared'
 
 import {
   ALLOWED_CONTEXT_KEYS,

--- a/src/hooks/use-fetch.ts
+++ b/src/hooks/use-fetch.ts
@@ -1,3 +1,4 @@
+'use client'
 import * as React from 'react'
 import { useState, useEffect } from 'react'
 
@@ -42,19 +43,21 @@ import {
 
 import {
   createImperativeFetch,
-  createRequestFn,
   getMiliseconds,
   getTimePassed,
+  revalidate
+} from '../utils'
+import {
+  createRequestFn,
   hasBaseUrl,
   isDefined,
   isFunction,
   notNull,
   queue,
-  revalidate,
   serialize,
   setURLParams,
   windowExists
-} from '../utils'
+} from '../utils/shared'
 
 /**
  * Fetch hook
@@ -1248,3 +1251,5 @@ useFetch.patch = createRequestFn('PATCH', '', {})
 useFetch.purge = createRequestFn('PURGE', '', {})
 useFetch.link = createRequestFn('LINK', '', {})
 useFetch.unlink = createRequestFn('UNLINK', '', {})
+
+useFetch.extend = createImperativeFetch

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-'use client'
 /**
  * @license http-react
  * Copyright (c) Dany Beltran
@@ -42,13 +41,17 @@ export {
 
 export { FetchConfig, SSRSuspense } from './components'
 
-export {
-  gql,
-  setURLParams,
-  queryProvider,
-  mutateData,
-  revalidate,
-  hasBaseUrl
-} from './utils'
+export { gql, queryProvider, mutateData, revalidate } from './utils'
 
 export { defaultCache } from './internal'
+
+export {
+  HttpReact,
+  setURLParams,
+  hasBaseUrl,
+  isDefined,
+  isFormData,
+  isFunction,
+  serialize,
+  notNull
+} from './utils/shared'

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -1,3 +1,4 @@
+'use client'
 import { createContext, useContext } from 'react'
 
 import { CacheStoreType, FetchContextType } from '../types'

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -1,0 +1,253 @@
+import { DEFAULT_RESOLVER, METHODS } from '../internal/constants'
+
+import { FetchContextType, ImperativeFetch, RequestWithBody } from '../types'
+
+export const windowExists = typeof window !== 'undefined'
+
+export function notNull(target: any) {
+  return target !== null
+}
+
+export function isDefined(target: any) {
+  return typeof target !== 'undefined'
+}
+
+export function isFunction(target: any) {
+  return typeof target === 'function'
+}
+
+export function hasBaseUrl(target: string) {
+  return target.startsWith('http://') || target.startsWith('https://')
+}
+
+export function jsonCompare(a: any, b: any) {
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+export function serialize(input: any) {
+  return JSON.stringify(input)
+}
+
+export const isFormData = (target: any) => {
+  if (typeof FormData !== 'undefined') {
+    return target instanceof FormData
+  } else return false
+}
+
+function canHaveBody(method: keyof typeof METHODS) {
+  return /(POST|PUT|DELETE|PATCH)/.test(method)
+}
+
+export function queue(callback: any, time: number = 0) {
+  const tm = setTimeout(() => {
+    callback()
+    clearTimeout(tm)
+  }, time)
+
+  return tm
+}
+
+/**
+ *
+ * @param str The target string
+ * @param $params The params to parse in the url
+ *
+ * Params should be separated by `"/"`, (e.g. `"/api/[resource]/:id"`)
+ *
+ * URL search params will not be affected
+ */
+export function setURLParams(str: string = '', $params: any = {}) {
+  const hasQuery = str.includes('?')
+
+  const queryString =
+    '?' +
+    str
+      .split('?')
+      .filter((_, i) => i > 0)
+      .join('?')
+
+  return (
+    str
+      .split('/')
+      .map($segment => {
+        const [segment] = $segment.split('?')
+        if (segment.startsWith('[') && segment.endsWith(']')) {
+          const paramName = segment.replace(/\[|\]/g, '')
+          if (!(paramName in $params)) {
+            console.warn(
+              `Param '${paramName}' does not exist in params configuration for '${str}'`
+            )
+            return paramName
+          }
+
+          return $params[segment.replace(/\[|\]/g, '')]
+        } else if (segment.startsWith(':')) {
+          const paramName = segment.split('').slice(1).join('')
+          if (!(paramName in $params)) {
+            console.warn(
+              `Param '${paramName}' does not exist in params configuration for '${str}'`
+            )
+            return paramName
+          }
+          return $params[paramName]
+        } else {
+          return segment
+        }
+      })
+      .join('/') + (hasQuery ? queryString : '')
+  )
+}
+
+/**
+ * Creates a new request function. This is for usage with fetcher and fetcher.extend
+ */
+export function createRequestFn(
+  method: string,
+  baseUrl: string,
+  $headers: any
+): RequestWithBody {
+  return async function (url, init = {}) {
+    const {
+      default: def,
+      params = {},
+      headers,
+      query = {},
+      body,
+      formatBody,
+      resolver = DEFAULT_RESOLVER,
+      onResolve = () => {},
+      onError = () => {}
+    } = init
+
+    const rawUrl = setURLParams(url, params)
+
+    const reqQueryString = Object.keys(query)
+      .map(q => [q, query[q]].join('='))
+      .join('&')
+
+    const reqConfig = {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        ...$headers,
+        ...headers
+      },
+      body: canHaveBody(method as any)
+        ? isFunction(formatBody)
+          ? (formatBody as any)(body)
+          : body
+        : undefined
+    }
+
+    let r = undefined as any
+
+    const requestUrl = [
+      baseUrl || '',
+      rawUrl,
+      url.includes('?') ? '&' : '?',
+      reqQueryString
+    ].join('')
+
+    try {
+      const req = await fetch(requestUrl, {
+        ...init,
+        ...reqConfig
+      })
+      r = req
+
+      const data = await resolver(req)
+      if (req?.status >= 400) {
+        onError(true as any)
+        return {
+          res: req,
+          data: def,
+          error: true,
+          code: req?.status,
+          config: {
+            ...init,
+            url: `${baseUrl || ''}${rawUrl}`,
+            ...reqConfig,
+            query
+          }
+        }
+      } else {
+        onResolve(data, req)
+        return {
+          res: req,
+          data: data,
+          error: false,
+          code: req?.status,
+          config: {
+            ...init,
+            url: `${baseUrl || ''}${rawUrl}`,
+            ...reqConfig,
+            query
+          }
+        }
+      }
+    } catch (err) {
+      onError(err as any)
+      return {
+        res: r,
+        data: def,
+        error: true,
+        code: r?.status,
+        config: {
+          ...init,
+          url: requestUrl,
+          ...reqConfig
+        }
+      }
+    }
+  } as RequestWithBody
+}
+
+const createImperativeFetch = (ctx: FetchContextType) => {
+  const keys = [
+    'GET',
+    'DELETE',
+    'HEAD',
+    'OPTIONS',
+    'POST',
+    'PUT',
+    'PATCH',
+    'PURGE',
+    'LINK',
+    'UNLINK'
+  ]
+
+  const { baseUrl } = ctx
+
+  return Object.fromEntries(
+    new Map(
+      keys.map(k => [
+        k.toLowerCase(),
+        (url, config = {}) =>
+          (HttpReact as any)[k.toLowerCase()](
+            hasBaseUrl(url) ? url : baseUrl + url,
+            {
+              ...ctx,
+              ...config
+            }
+          )
+      ])
+    )
+  ) as ImperativeFetch
+}
+
+const HttpReact = () => {}
+
+HttpReact.get = createRequestFn('GET', '', {})
+HttpReact.delete = createRequestFn('DELETE', '', {})
+HttpReact.head = createRequestFn('HEAD', '', {})
+HttpReact.options = createRequestFn('OPTIONS', '', {})
+HttpReact.post = createRequestFn('POST', '', {})
+HttpReact.put = createRequestFn('PUT', '', {})
+HttpReact.patch = createRequestFn('PATCH', '', {})
+HttpReact.purge = createRequestFn('PURGE', '', {})
+HttpReact.link = createRequestFn('LINK', '', {})
+HttpReact.unlink = createRequestFn('UNLINK', '', {})
+
+HttpReact.extend = createImperativeFetch
+
+export { HttpReact }


### PR DESCRIPTION
### Feat: `HttpReact` client (works with sever components)

- Adds the `HttpReact` object, which can be used to make requests imperatively. It has a method for each HTTP verb, like `get`, `post`, etc. It also has an `extend` method, similar to `axios.create`

Example with a sever component in Next.js:

```jsx
import { HttpReact } from 'http-react'
import { cookies } from 'next/headers'

export default async function MyServerPage() {
  const session = cookies().get('appSession')?.value

  const { data, error } = await HttpReact.get('/api/auth', {
    headers: { Authorization: 'Token ' + session }
  })

  if (!data || error) return <Login />

  return <App />
}

```

Using `.extend`:

```jsx
import { HttpReact } from 'http-react'

const client = HttpReact.extend({
  baseUrl: '/api',
  headers: {
    Authorization: 'Token'
  }
})

export default async function MyServerPage() {
  const { data, error } = await client.get('/auth')

  if (!data || error) return <Login />

  return <App />
}
```

This also works in client-side components and with `getServerSideProps`