### PR TITLE
Feat fetchconfig re exp sc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 index.js.map
 package-lock.json
 yarn.lock
+server.js
+server.d.ts

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react",
-  "version": "2.7.1",
+  "version": "2.7.5",
   "description": "React hooks for data fetching",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "React hooks for data fetching",
   "main": "dist/index.js",
   "scripts": {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,0 +1,2 @@
+'use client'
+export { FetchConfig } from '../components'

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -1,3 +1,4 @@
+import {} from '../'
 export default {
   GET: {
     careers: [


### PR DESCRIPTION
Adds re-export of `FetchConfig` that can be used inside Next.js's server components:

```jsx
import { FetchConfig } from 'http-react/dist/server'

export default async function Layout({ children }) {
  return (
    <div>
      <FetchConfig baseUrl='/api'>{children}</FetchConfig>
    </div>
  )
}

```