### PR TITLE
Feat(Server):

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react",
-  "version": "2.7.5",
+  "version": "2.7.8",
   "description": "React hooks for data fetching",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/server/index.tsx
+++ b/src/components/server/index.tsx
@@ -1,0 +1,2 @@
+'use client'
+export { FetchConfig, SSRSuspense } from '../index'

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ export {
   useRequestStart
 } from './hooks'
 
-export { FetchConfig, SSRSuspense } from './components'
+export { FetchConfig, SSRSuspense } from './components/server'
 
 export { gql, queryProvider, mutateData, revalidate } from './utils'
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,2 +1,0 @@
-'use client'
-export { FetchConfig } from '../components'


### PR DESCRIPTION
re-exports FetchConfig and SSRSuspense from separate module with `use client` directive. Now `FetchConfig` can be imported directly from `http-react` instead of `http-react/dist/server` when using Server components