### PR TITLE
Feat(renders, onFetchStart, onFetchEnd):

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react",
-  "version": "2.7.8",
+  "version": "2.7.9",
   "description": "React hooks for data fetching",
   "main": "dist/index.js",
   "scripts": {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -26,5 +26,6 @@ export {
   useUNLINK,
   useResolve,
   useGql,
-  useImperative
+  useImperative,
+  useFetchSuspense
 } from './others'

--- a/src/hooks/others.ts
+++ b/src/hooks/others.ts
@@ -46,6 +46,24 @@ export function useFetchConfig(id?: unknown) {
   return thisConfig as FetchInit & FetchContextType
 }
 
+export function useFetchSuspense<FetchDataType = any, BodyType = any>(
+  init: FetchConfigType<FetchDataType, BodyType> | string,
+  options?: FetchConfigTypeNoUrl<FetchDataType, BodyType>
+) {
+  let o =
+    typeof init === 'string'
+      ? {
+          url: init,
+          ...options
+        }
+      : options
+
+  return useFetch({
+    ...o,
+    suspense: true
+  })
+}
+
 /**
  * Get the data state of a request using its id
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,8 @@ export {
   useResolve,
   useResponseTime,
   useRequestEnd,
-  useRequestStart
+  useRequestStart,
+  useFetchSuspense
 } from './hooks'
 
 export { FetchConfig, SSRSuspense } from './components/server'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,6 +46,16 @@ export type FetchContextType = {
   retryOnReconnect?: boolean
   cacheProvider?: CacheStoreType
   revalidateOnMount?: boolean
+  onFetchStart?(
+    req: Request,
+    config: FetchConfigType,
+    ctx: FetchContextType
+  ): void
+  onFetchEnd?(
+    res: Response,
+    config: FetchConfigType,
+    ctx: FetchContextType
+  ): void
 } & Omit<RequestInit, 'body'>
 
 export type CacheStoreType = {
@@ -281,6 +291,14 @@ export type FetchConfigType<FetchDataType = any, BodyType = any> = Omit<
    * The time to wait before revalidation after props change
    */
   debounce?: TimeSpan
+  /**
+   * Will run when the request is sent
+   */
+  onFetchStart?: FetchContextType['onFetchStart']
+  /**
+   * Will run when the response is received
+   */
+  onFetchEnd?: FetchContextType['onFetchEnd']
 }
 
 // If first argument is a string


### PR DESCRIPTION
### Feats and fixes

- Reduces the ammount of unnecesary renders by using `React.startTransition`
- Adds `onFetchStart` and `onFetchEnd` configuration, which can help keep track of every request that is sent using `useFetch` (this is configurable globaly with `FetchConfig` or per-request)
- Adds `useFetchSuspense` hook that will always make a request using `suspense`