### PR TITLE
(error, cacheIfError):

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "description": "React hooks for data fetching",
   "main": "dist/index.js",
   "scripts": {

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -135,7 +135,7 @@ export const requestsProvider = {
   }
 }
 
-const defaultContextVaue = {
+const defaultContextVaue: FetchContextType = {
   defaults: DEFAULTS,
   attempts: ATTEMPTS,
   attemptInterval: ATTEMPT_INTERVAL,
@@ -146,7 +146,8 @@ const defaultContextVaue = {
   onOnline: ON_ONLINE,
   online: ONLINE,
   retryOnReconnect: RETRY_ON_RECONNECT,
-  revalidateOnMount: REVALIDATE_ON_MOUNT
+  revalidateOnMount: REVALIDATE_ON_MOUNT,
+  cacheIfError: true
 }
 
 export const FetchContext = createContext<FetchContextType>(defaultContextVaue)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,6 +46,7 @@ export type FetchContextType = {
   retryOnReconnect?: boolean
   cacheProvider?: CacheStoreType
   revalidateOnMount?: boolean
+  cacheIfError?: boolean
   onFetchStart?(
     req: Request,
     config: FetchConfigType,
@@ -299,6 +300,12 @@ export type FetchConfigType<FetchDataType = any, BodyType = any> = Omit<
    * Will run when the response is received
    */
   onFetchEnd?: FetchContextType['onFetchEnd']
+  /**
+   * If `true`, the last resolved value be returned as `data` if the request fails. If `false`, the default value will be returned instead
+   *
+   * @default true
+   */
+  cacheIfError?: boolean
 }
 
 // If first argument is a string


### PR DESCRIPTION
### Fix(error):
Fixes the `error` state being `true` after props change in the `useFetch` that initialized the request after a request fails

### Feat(cacheIfError):
Adds the `cacheIfError` option, which tells `useFetch` to use the last resolved value as `data` if the request fails (by default it's `true`). If `false`, the default value will be returned