### PR TITLE
fix(re-renders), feat(additional hooks):

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react",
-  "version": "2.8.3",
+  "version": "2.9.0",
   "description": "React hooks for data fetching",
   "main": "dist/index.js",
   "scripts": {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -27,5 +27,12 @@ export {
   useResolve,
   useGql,
   useImperative,
-  useFetchSuspense
+  useFetchSuspense,
+  useExpiration,
+  useHasData,
+  useLoadingFirst,
+  useOnline,
+  useReFetch,
+  useRevalidating,
+  useSuccess
 } from './others'

--- a/src/hooks/others.ts
+++ b/src/hooks/others.ts
@@ -192,6 +192,34 @@ export function useFetchMutate<T = any>(
   return mutate
 }
 
+export function useOnline(id: any) {
+  return useFetch({ id }).online
+}
+
+export function useLoadingFirst(id: any) {
+  return useFetch({ id }).loadingFirst
+}
+
+export function useReFetch(id: any) {
+  return useFetch({ id }).reFetch
+}
+
+export function useRevalidating(id: any) {
+  return useFetch({ id }).revalidating
+}
+
+export function useExpiration(id: any) {
+  return useFetch({ id }).expiration
+}
+
+export function useHasData(id: any) {
+  return useFetch({ id }).hasData
+}
+
+export function useSuccess(id: any) {
+  return useFetch({ id }).success
+}
+
 /**
  * Get everything from a `useFetch` call using its id
  */

--- a/src/hooks/use-fetch.ts
+++ b/src/hooks/use-fetch.ts
@@ -72,7 +72,7 @@ export function useFetch<FetchDataType = any, BodyType = any>(
 ) {
   const ctx = useHRFContext()
 
-  const isRequest = init instanceof Request
+  const isRequest = init instanceof Object && init?.json
 
   const optionsConfig =
     typeof init === 'string'
@@ -88,7 +88,7 @@ export function useFetch<FetchDataType = any, BodyType = any>(
           init,
           ...options
         }
-      : init
+      : (init as FetchConfigType<FetchDataType, BodyType>)
 
   const {
     onOnline = ctx.onOnline,

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,15 @@ export {
   useResponseTime,
   useRequestEnd,
   useRequestStart,
-  useFetchSuspense
+  useFetchSuspense,
+  useExpiration,
+  useFetch,
+  useHasData,
+  useLoadingFirst,
+  useOnline,
+  useReFetch,
+  useRevalidating,
+  useSuccess
 } from './hooks'
 
 export { FetchConfig, SSRSuspense } from './components/server'
@@ -46,7 +54,7 @@ export { gql, queryProvider, mutateData, revalidate } from './utils'
 export { defaultCache } from './internal'
 
 export {
-  HttpReact,
+  Client,
   setURLParams,
   hasBaseUrl,
   isDefined,

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -39,6 +39,27 @@ export const previousProps: any = {}
 export const valuesMemory: any = {}
 
 /**
+ * Online / offline
+ */
+export const onlineHandled: any = {}
+
+export const offlineHandled: any = {}
+
+/**
+ * To let know if it's revalidating there is at least one succesful request
+ */
+
+export const hasData: any = {}
+
+/**
+ * Max pagination age
+ */
+
+export const pageStarted: any = {}
+
+export const maxAges: any = {}
+
+/**
  * For Suspense
  */
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -57,6 +57,7 @@ export type FetchContextType = {
     config: FetchConfigType,
     ctx: FetchContextType
   ): void
+  maxCacheAge?: TimeSpan
 } & Omit<RequestInit, 'body'>
 
 export type CacheStoreType = {
@@ -306,6 +307,19 @@ export type FetchConfigType<FetchDataType = any, BodyType = any> = Omit<
    * @default true
    */
   cacheIfError?: boolean
+  /**
+   * If `true`, the request will be overwriten with other configurations passed to `useFetch` (such as method, query, params, body, etc)
+   * @default true
+   */
+  overwrite?: boolean
+  /**
+   * The max age a page should be cached (with no request)
+   */
+  maxCacheAge?: TimeSpan
+  /**
+   * Similar to `resolver` but takes the data coming from resolver instead of the actual response
+   */
+  middleware?: <R = FetchDataType>(data: R) => FetchDataType
 }
 
 // If first argument is a string

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -8,6 +8,11 @@ export function notNull(target: any) {
   return target !== null
 }
 
+export function getRequestHeaders(req: Request) {
+  // @ts-ignore Gets the request headers
+  return Object.fromEntries(new Headers(req.headers).entries())
+}
+
 export function isDefined(target: any) {
   return typeof target !== 'undefined'
 }
@@ -223,7 +228,7 @@ const createImperativeFetch = (ctx: FetchContextType) => {
       keys.map(k => [
         k.toLowerCase(),
         (url, config = {}) =>
-          (HttpReact as any)[k.toLowerCase()](
+          (Client as any)[k.toLowerCase()](
             hasBaseUrl(url) ? url : baseUrl + url,
             {
               ...ctx,
@@ -235,19 +240,19 @@ const createImperativeFetch = (ctx: FetchContextType) => {
   ) as ImperativeFetch
 }
 
-const HttpReact = () => {}
+const Client = () => {}
 
-HttpReact.get = createRequestFn('GET', '', {})
-HttpReact.delete = createRequestFn('DELETE', '', {})
-HttpReact.head = createRequestFn('HEAD', '', {})
-HttpReact.options = createRequestFn('OPTIONS', '', {})
-HttpReact.post = createRequestFn('POST', '', {})
-HttpReact.put = createRequestFn('PUT', '', {})
-HttpReact.patch = createRequestFn('PATCH', '', {})
-HttpReact.purge = createRequestFn('PURGE', '', {})
-HttpReact.link = createRequestFn('LINK', '', {})
-HttpReact.unlink = createRequestFn('UNLINK', '', {})
+Client.get = createRequestFn('GET', '', {})
+Client.delete = createRequestFn('DELETE', '', {})
+Client.head = createRequestFn('HEAD', '', {})
+Client.options = createRequestFn('OPTIONS', '', {})
+Client.post = createRequestFn('POST', '', {})
+Client.put = createRequestFn('PUT', '', {})
+Client.patch = createRequestFn('PATCH', '', {})
+Client.purge = createRequestFn('PURGE', '', {})
+Client.link = createRequestFn('LINK', '', {})
+Client.unlink = createRequestFn('UNLINK', '', {})
 
-HttpReact.extend = createImperativeFetch
+Client.extend = createImperativeFetch
 
-export { HttpReact }
+export { Client }


### PR DESCRIPTION
### Fixes: 
- Reduces re-renders by using a single state variable instead of 6 and setting the new request state in the `finally` block
- `useFetch` now returns more properties. The new properties are:
  - `revalidating`: This is `true` if at least one request has completed succesfuly and a new request is being sent
  - `hasData`: This is `true` if data is not `undefined` or `null`
  - `success`: This is `true` if there is no error and the request is not loading
  - 'loadingFirst`: This is 'true' if the request is being sent for the first time and becomes `false` in subsequent requests
  - `expiration`: This is a `Date` object of the expiration date of the data. This will depend on the `maxCacheAge` property passed to `useFetch`

Feat: A `Request` instance can be passed to `useFetch` instead of just a `URL`. `useFetch` will get the properties of the `Request` passed and include them in a new request. This is useful if you have existing requests. Caveats:
Example:

```jsx
import useFetch from 'http-react'

// an instance of Request
const ApiRequest = new Request('https:/api/[resource]/[id]', {
  headers: {
    Authorization: 'Token'
  }
})

function Profile() {
  const { data, hasData } = useFetch(ApiRequest, {
    params: {
      resource: 'profile',
      id: 12
    }
  })
  if (!hasData) return <p>Loading....</p>

  return (
    <div>
      <h2>{data.name}</h2>
    </div>
  )
}
```
> The 'url' and 'method' of the request will still be used for deduplication if no 'id' is provided

More configurations:
- You can now pass a `maxCacheAge` property to `useFetch`. (It can have the same shape as  `refresh` or `debounce`). With this, new requests will not be sent until the data has expired (this is done using timestampts that are stored in the `cacheProvider`, so if you are using a persistent cache like 'localStorage' or 'sessionStorage', a full page reload will not send a new request and return the cached data instead). You will be able to see the exact time the data will expire by reading the `expiration` property returned from `useFetch`. If no requests have been sent for that particular configuration, `null` will be returned instead

Additional hooks:
Added more hooks for the configurations above. They work by passing them the request id (See). They are:
- `useOnline`: Returns the `online` status of the request
- `useLoadingFirst`: Returns `true` if a request is being sent for the first time
- `useRevalidating`: Returns `true` if at least one request has completed and `loading` is true
- `useExpiration`: Returns the expiration date of the last data retrieved from `useFetch`
- `useHasData`: Returns `true` if `data` is not null or `undefined`
- `useSuccess`: Returns `true` if the request completed succcesfuly and loading is `true`. `false` if the request is loading.

Additionaly, a new hook for `reFetch` was added:
- `useReFetch`: Returns the function that will revalidate a request using its id