### PR TITLE
fix(cacheIfError, hasData):

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "React hooks for data fetching",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
#### Fix: `cacheIfError`, `hasData`:

- Returns `null` or data correctly when `cacheIfError = false`. However, if `default` is present, that would be returned instead of `null`.
- `error` and `hasData` are now boolean values instead of `true | null` for better usage (for example, `error.toString()` would not throw the `cannot read property toString of null` error).