### PR TITLE
Fix loading maxcacheage debounce

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "description": "React hooks for data fetching",
   "main": "dist/index.js",
   "scripts": {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -34,5 +34,6 @@ export {
   useOnline,
   useReFetch,
   useRevalidating,
-  useSuccess
+  useSuccess,
+  useDebounceFetch
 } from './others'

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,12 +44,19 @@ export {
   useOnline,
   useReFetch,
   useRevalidating,
-  useSuccess
+  useSuccess,
+  useDebounceFetch
 } from './hooks'
 
 export { FetchConfig, SSRSuspense } from './components/server'
 
-export { gql, queryProvider, mutateData, revalidate } from './utils'
+export {
+  gql,
+  queryProvider,
+  mutateData,
+  revalidate,
+  cancelRequest
+} from './utils'
 
 export { defaultCache } from './internal'
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -291,6 +291,7 @@ export type FetchConfigType<FetchDataType = any, BodyType = any> = Omit<
   formatBody?: boolean | ((b: BodyType) => any)
   /**
    * The time to wait before revalidation after props change
+   * @deprecated Use the `useDebounceFetch` hook instead
    */
   debounce?: TimeSpan
   /**


### PR DESCRIPTION
- Fixed `loading` being `true` when revalidating if cache exp. > date
- Added useDebounceFetch to replace passing `debounce` to `useFetch`
- Checks if `maxCacheAge` has changed between renders to invalidate existing cache