### PR TITLE
feat(useFetch, requestStart, requestEnd, expiration):

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ It supports many features that are necessary in modern applications, while givin
 - Refresh
 - Retry on error
 - Pagination
-- Local mutation
+- Local mutation (Optimistic UI)
 - qraphql
 
 and [more](https://http-react.netlify.app/docs/api)!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "description": "React hooks for data fetching",
   "main": "dist/index.js",
   "scripts": {

--- a/src/hooks/use-fetch.ts
+++ b/src/hooks/use-fetch.ts
@@ -64,6 +64,13 @@ import {
 } from '../utils/shared'
 
 /**
+ * Passing `undefined` to `new Date()` returns `Invalid Date {}`, so return null instead
+ */
+const getDateIfValid = (d: Date | null) =>
+  // @ts-ignore - Evals to a Date
+  (d?.toString() === 'Invalid Date' || d === null ? null : d) as Date
+
+/**
  * Fetch hook
  */
 export function useFetch<FetchDataType = any, BodyType = any>(
@@ -1418,9 +1425,9 @@ export function useFetch<FetchDataType = any, BodyType = any>(
     hasData: oneRequestResolved,
     success: isSuccess,
     loadingFirst,
-    requestStart: $requestStart,
-    requestEnd: $requestEnd,
-    expiration: isFailed ? null : expirationDate,
+    requestStart: getDateIfValid($requestStart),
+    requestEnd: getDateIfValid($requestEnd),
+    expiration: getDateIfValid(isFailed ? null : expirationDate),
     responseTime: requestResponseTimes[resolvedDataKey] ?? null,
     data: responseData,
     loading: isLoading,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,9 @@
 
 export type { CacheStoreType, FetchInit } from './types'
 
-export { useFetch as default } from './hooks'
+import { useFetch } from './hooks'
+
+export default useFetch
 
 export {
   useData,
@@ -38,7 +40,6 @@ export {
   useRequestStart,
   useFetchSuspense,
   useExpiration,
-  useFetch,
   useHasData,
   useLoadingFirst,
   useOnline,

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -29,8 +29,11 @@ export function jsonCompare(a: any, b: any) {
   return JSON.stringify(a) === JSON.stringify(b)
 }
 
-export function serialize(input: any) {
-  return JSON.stringify(input)
+/**
+ * A serialize function that returns a JSON string
+ */
+export function serialize(input: any, replacer?: any, space?: any) {
+  return JSON.stringify(input, replacer, space)
 }
 
 export const isFormData = (target: any) => {
@@ -240,19 +243,21 @@ const createImperativeFetch = (ctx: FetchContextType) => {
   ) as ImperativeFetch
 }
 
-const Client = () => {}
-
-Client.get = createRequestFn('GET', '', {})
-Client.delete = createRequestFn('DELETE', '', {})
-Client.head = createRequestFn('HEAD', '', {})
-Client.options = createRequestFn('OPTIONS', '', {})
-Client.post = createRequestFn('POST', '', {})
-Client.put = createRequestFn('PUT', '', {})
-Client.patch = createRequestFn('PATCH', '', {})
-Client.purge = createRequestFn('PURGE', '', {})
-Client.link = createRequestFn('LINK', '', {})
-Client.unlink = createRequestFn('UNLINK', '', {})
-
-Client.extend = createImperativeFetch
+/**
+ * An Client for making HTTP Requests
+ */
+const Client = {
+  get: createRequestFn('GET', '', {}),
+  delete: createRequestFn('DELETE', '', {}),
+  head: createRequestFn('HEAD', '', {}),
+  options: createRequestFn('OPTIONS', '', {}),
+  post: createRequestFn('POST', '', {}),
+  put: createRequestFn('PUT', '', {}),
+  patch: createRequestFn('PATCH', '', {}),
+  purge: createRequestFn('PURGE', '', {}),
+  link: createRequestFn('LINK', '', {}),
+  unlink: createRequestFn('UNLINK', '', {}),
+  extend: createImperativeFetch
+}
 
 export { Client }


### PR DESCRIPTION
- Makes `useFetch` the default export
- Returns `null` in dates if `expiration`, `end`, or `start` Dates are Invalid Dates
- The `serialize` function now accepts the `replacer` function and the `spaces` args.
- Makes `Client` an object with its different methods instead of a function that gets its methods prototyped after its creation