### PR TITLE
fix(loading):

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react",
-  "version": "2.9.8",
+  "version": "2.9.9",
   "description": "React hooks for data fetching",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
### fix: `loading`

Revalidating a request won't set `loading` to `false` between invalidation and revalidation, instead it will keep `loading` to `true` as long as revalidation is triggered. This does not apply to the `cancelRequest` function, which immediately sets `loading` to `false`