### PR TITLE
feat(re-renders):

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "React hooks for data fetching",
   "main": "dist/index.js",
   "scripts": {

--- a/src/hooks/others.ts
+++ b/src/hooks/others.ts
@@ -128,7 +128,7 @@ export function useFetchCode(id: any) {
 export function useFetchLoading(id: any): boolean {
   const idString = serialize({ idString: serialize(id) })
 
-  const { data } = useFetch({
+  const { loading } = useFetch({
     id: id
   })
 


### PR DESCRIPTION
`reFetch` only re-renders when the accessed values change. This is done by keeping track of which values are read with `React.useRef`. For example, you may have a component that only reads the `error` returned by `useFetch`, in that case, the component will re-render only then the request fails. Same with `loading` and `data`