### PR TITLE
feat(useManualFetch):

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "http-react",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "React hooks for data fetching",
   "main": "dist/index.js",
   "scripts": {
-    "test": "jest",
+    "test": "tsc && webpack --mode production && jest",
     "compile": "tsc && webpack --mode production"
   },
   "repository": {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -12,6 +12,7 @@ export {
   useFetchBlob as useBlob,
   useFetchText as useText,
   useFetchResponseTime as useResponseTime,
+  useManualFetch,
   useRequestEnd,
   useRequestStart,
   useGET,

--- a/src/hooks/others.ts
+++ b/src/hooks/others.ts
@@ -422,6 +422,19 @@ export function useUNLINK<FetchDataType = any, BodyType = any>(
 }
 
 /**
+ * Use a request without making it automatically
+ */
+export function useManualFetch<FetchDataType = any, BodyType = any>(
+  init: FetchConfigType<FetchDataType, BodyType> | string,
+  options?: FetchConfigTypeNoUrl<FetchDataType, BodyType>
+) {
+  return useFetch(init, {
+    ...options,
+    auto: false
+  })
+}
+
+/**
  * Get a blob of the response. You can pass an `objectURL` property that will convet that blob into a string using `URL.createObjectURL`
  */
 export function useFetchBlob<FetchDataType = string, BodyType = any>(

--- a/src/hooks/use-fetch.ts
+++ b/src/hooks/use-fetch.ts
@@ -80,6 +80,7 @@ export function useFetch<FetchDataType = any, BodyType = any>(
 ) {
   const ctx = useHRFContext()
 
+  // @ts-ignore
   const isRequest = init instanceof Object && init?.json
 
   const optionsConfig =
@@ -535,6 +536,7 @@ export function useFetch<FetchDataType = any, BodyType = any>(
           try {
             let reqConfig = {}
 
+            // @ts-ignore
             let _headers = isRequest ? getRequestHeaders(init) : {}
 
             if (isRequest) {
@@ -770,6 +772,7 @@ export function useFetch<FetchDataType = any, BodyType = any>(
           } catch (err) {
             const errorString = err?.toString()
             // Only set error if no abort
+            // @ts-ignore
             if (!/abort/i.test(errorString)) {
               if (!cacheIfError) {
                 hasData[resolvedDataKey] = false

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export {
   useLINK,
   useLoading,
   useMutate,
+  useManualFetch,
   useOPTIONS,
   usePATCH,
   usePOST,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -163,7 +163,7 @@ export type FetchConfigType<FetchDataType = any, BodyType = any> = Omit<
     blob?: any
     text?: any
   }>
-  body?: BodyType
+  body?: any
   /**
    * Any serializable id. This is optional.
    */


### PR DESCRIPTION
Adds the `useManualFetch` hook, which makes a fetch only when triggered manually

Example:

```jsx
import { useManualFetch, serialize } from 'http-react'

export default function Home() {
  const { data, reFetch } = useManualFetch('https://jsonplaceholder.typicode.com/todos/3')

  return (
    <main>
      <button onClick={reFetch}>Request now</button>
      <hr />
      <pre>{serialize(data, null, 2)}</pre>
    </main>
  )
}

```

> In this case, while the `Request now` button is not clicked, `data` will be `undefined`