### PR TITLE
fix(Query):

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "React hooks for data fetching",
   "main": "dist/index.js",
   "scripts": {

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,6 +1,8 @@
 'use client'
 export { useFetch } from './use-fetch'
 
+export { useIsomorphicLayoutEffect } from '../utils'
+
 export {
   useFetchLoading as useLoading,
   useFetchConfig as useConfig,

--- a/src/hooks/use-fetch.ts
+++ b/src/hooks/use-fetch.ts
@@ -487,7 +487,7 @@ export function useFetch<FetchDataType = any, BodyType = any>(
 
       const realUrl =
         urlWithParams +
-        (urlWithParams.includes('?') ? (c?.query !== '' ? `&` : '') : '?')
+        (urlWithParams.includes('?') ? (c?.query !== '' ? `&` : '') : '')
 
       if (previousConfig[resolvedKey] !== serialize(optionsConfig)) {
         previousProps[resolvedKey] = optionsConfig
@@ -585,7 +585,17 @@ export function useFetch<FetchDataType = any, BodyType = any>(
                   }
             ) as any
 
-            const r = new Request(realUrl + c.query, newRequestConfig)
+            const r = new Request(
+              (
+                realUrl +
+                (realUrl.includes('?')
+                  ? c.query
+                  : c.query
+                  ? '?' + c.query
+                  : c.query)
+              ).replace('?&', '?'),
+              newRequestConfig
+            )
 
             if (logStart) {
               ;(onFetchStart as any)(r, optionsConfig, ctx)
@@ -995,7 +1005,13 @@ export function useFetch<FetchDataType = any, BodyType = any>(
         if (url !== '') {
           fetchData({
             query: Object.keys(reqQuery)
-              .map(q => [q, reqQuery[q]].join('='))
+              .map(q =>
+                Array.isArray(reqQuery[q])
+                  ? reqQuery[q]
+                      .map((queryItem: any) => [q, queryItem].join('='))
+                      .join('&')
+                  : [q, reqQuery[q]].join('=')
+              )
               .join('&'),
             params: reqParams
           })
@@ -1183,7 +1199,13 @@ export function useFetch<FetchDataType = any, BodyType = any>(
         if (url !== '') {
           d = await fetchData({
             query: Object.keys(reqQuery)
-              .map(q => [q, reqQuery[q]].join('='))
+              .map(q =>
+                Array.isArray(reqQuery[q])
+                  ? reqQuery[q]
+                      .map((queryItem: any) => [q, queryItem].join('='))
+                      .join('&')
+                  : [q, reqQuery[q]].join('=')
+              )
               .join('&'),
             params: reqParams
           })

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,8 @@ export {
   useRevalidating,
   useSuccess,
   useDebounceFetch,
-  createActionsHook
+  createActionsHook,
+  useIsomorphicLayoutEffect
 } from './hooks'
 
 export { FetchConfig, SSRSuspense } from './components/server'

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -131,7 +131,11 @@ export function createRequestFn(
     const rawUrl = setURLParams(url, params)
 
     const reqQueryString = Object.keys(query)
-      .map(q => [q, query[q]].join('='))
+      .map(q =>
+        Array.isArray(query[q])
+          ? query[q].map((queryItem: any) => [q, queryItem].join('=')).join('&')
+          : [q, query[q]].join('=')
+      )
       .join('&')
 
     const reqConfig = {
@@ -153,8 +157,10 @@ export function createRequestFn(
     const requestUrl = [
       baseUrl || '',
       rawUrl,
-      url.includes('?') ? '&' : '?',
       reqQueryString
+        ? (rawUrl.includes('?') ? (rawUrl.endsWith('?') ? '' : '&') : '?') +
+          reqQueryString
+        : ''
     ].join('')
 
     try {


### PR DESCRIPTION
- Removes unnecessary '?' at end of urls that don't have query params
- Adds support for array query params

Added support for lists of search params. Example:

```tsx
"use client"

import useFetch from "@/httpreact"

export default function Home() {
  const { data } = useFetch("/api/something/1", {
    query: {
      a: 1,
      b: [2, 3, 4, "hello there"],
    },
  })

  return (
    <main className="p-24">
      <h2>Home page</h2>
      <pre>{serialize(data, null, 2)}</pre>
    </main>
  )
}

```

The requested url will be: `/api/something/1?a=1&b=2&b=3&b=4&b=hello%20there`, and the network tab should show something like this:

![image](https://github.com/atomic-state/http-react/assets/30043027/690be927-7c70-49f2-b675-a949609946e2)
