### PR TITLE
feat(value, useServerMutation, actionResult)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 <img src="https://github.com/atomic-state/http-react/actions/workflows/test.yml/badge.svg?event=push" />
 </p>
 
-
 Http React is a React hooks library for data fetching. It's built on top of the native `Fetch` API.
 
 ### Overview
@@ -14,13 +13,13 @@ Http React is a React hooks library for data fetching. It's built on top of the 
 With one hook call, you get all the information about a request that you can use to build UIs that are consistent and performant:
 
 ```jsx
-import useFetch from "http-react"
+import useFetch from 'http-react'
 
 // This is the default
 const fetcher = (url, config) => fetch(url, config)
 
 export default function App() {
-  const { data, loading, error, responseTime } = useFetch("/api/user-info", {
+  const { data, loading, error, responseTime } = useFetch('/api/user-info', {
     refresh: '30 sec',
     fetcher
   })
@@ -41,6 +40,7 @@ export default function App() {
 It supports many features that are necessary in modern applications, while giving developers full control over the request configuration:
 
 - Server-Side Rendering
+- Server actions
 - React Native
 - Request deduplication
 - Suspense
@@ -82,8 +82,4 @@ For production apps
 <script src="https://unpkg.com/http-react/dist/browser/http-react.min.js"></script>
 ```
 
-
-
 [Getting started](https://http-react.netlify.app/docs)
-
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "http-react",
-  "version": "3.2.9",
+  "version": "3.3.0",
   "description": "React hooks for data fetching",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -39,11 +39,28 @@ export function SSRSuspense({
 }
 
 export function FetchConfig(props: FetchContextType) {
-  const { children, defaults = {}, suspense = [] } = props
+  const { children, defaults = {}, value = {}, suspense = [] } = props
 
   const previousConfig = useHRFContext()
 
   const { cacheProvider = defaultCache } = previousConfig
+
+  for (let valueKey in value) {
+    const resolvedKey = serialize({
+      idString: serialize(valueKey)
+    })
+
+    if (!isDefined(valuesMemory.get(resolvedKey))) {
+      valuesMemory.set(resolvedKey, value[valueKey])
+    }
+    if (!isDefined(fetcherDefaults.get(resolvedKey))) {
+      fetcherDefaults.set(resolvedKey, value[valueKey])
+    }
+
+    if (!isDefined(cacheProvider.get(resolvedKey))) {
+      cacheProvider.set(resolvedKey, value[valueKey])
+    }
+  }
 
   for (let defaultKey in defaults) {
     const { id = defaultKey } = defaults[defaultKey]

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -39,5 +39,6 @@ export {
   useRevalidating,
   useSuccess,
   useDebounceFetch,
-  useServerAction
+  useServerAction,
+  useServerMutation
 } from './others'

--- a/src/hooks/others.ts
+++ b/src/hooks/others.ts
@@ -652,7 +652,10 @@ function getMockServerActionId(action: any) {
   let mockServerActionId = serverActionIds.get(action)
 
   if (!mockServerActionId) {
-    mockServerActionId = crypto.randomUUID()
+    let mockServerActionId = `${Math.random()}`.split('.')[1]
+    try {
+      mockServerActionId = crypto.randomUUID()
+    } catch {}
 
     serverActionIds.set(action, mockServerActionId)
   }
@@ -679,9 +682,12 @@ export function useServerAction<T extends (args: any) => any>(
   config?: Omit<
     FetchConfigTypeNoUrl<Awaited<ReturnType<T>>['data']>,
     'params'
-  > & {
-    params?: Parameters<T>[0]
-  }
+  > &
+    (Parameters<T>[0] extends typeof undefined
+      ? {}
+      : {
+          params: Parameters<T>[0]
+        })
 ) {
   let mockServerActionId = getMockServerActionId(action)
 
@@ -697,5 +703,28 @@ export function useServerAction<T extends (args: any) => any>(
     },
     id: mockServerActionId,
     ...config
+  })
+}
+
+/**
+ * `useServerMutation` works exactly like `useServerAction` except it is not automatic
+ */
+
+export function useServerMutation<T extends (args: any) => any>(
+  action: T,
+  config?: Omit<
+    FetchConfigTypeNoUrl<Awaited<ReturnType<T>>['data']>,
+    'params'
+  > &
+    (Parameters<T>[0] extends typeof undefined
+      ? {}
+      : {
+          params: Parameters<T>[0]
+        })
+) {
+  // @ts-expect-error
+  return useServerAction(action, {
+    ...config,
+    auto: false
   })
 }

--- a/src/hooks/use-fetch.ts
+++ b/src/hooks/use-fetch.ts
@@ -1434,6 +1434,10 @@ export function useFetch<FetchDataType = any, BodyType = any>(
       thisDeps.loading = true
       return oneRequestResolved && isLoading
     },
+    get isRevalidating() {
+      thisDeps.loading = true
+      return oneRequestResolved && isLoading
+    },
     get hasData() {
       thisDeps.data = true
       return oneRequestResolved
@@ -1444,6 +1448,10 @@ export function useFetch<FetchDataType = any, BodyType = any>(
       return isSuccess
     },
     get loadingFirst() {
+      thisDeps.loading = true
+      return loadingFirst
+    },
+    get isLoadingFirst() {
       thisDeps.loading = true
       return loadingFirst
     },
@@ -1468,6 +1476,10 @@ export function useFetch<FetchDataType = any, BodyType = any>(
       return responseData
     },
     get loading() {
+      thisDeps.loading = true
+      return isLoading
+    },
+    get isLoading() {
       thisDeps.loading = true
       return isLoading
     },
@@ -1529,9 +1541,12 @@ export function useFetch<FetchDataType = any, BodyType = any>(
     revalidating: boolean
     success: boolean
     loadingFirst: boolean
+    isLoadingFirst: boolean
     expiration: Date
     data: FetchDataType
     loading: boolean
+    isLoading: boolean
+    isRevalidating: boolean
     error: Error | null
     online: boolean
     code: number

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,8 @@ export {
   useSuccess,
   useDebounceFetch,
   useIsomorphicLayoutEffect,
-  useServerAction
+  useServerAction,
+  useServerMutation
 } from './hooks'
 
 export { FetchConfig, SSRSuspense } from './components/server'
@@ -74,5 +75,6 @@ export {
   serialize,
   notNull,
   setQueryParams,
-  setParamsAndQuery
+  setParamsAndQuery,
+  actionResult
 } from './utils/shared'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,8 +24,20 @@ export type FetchContextType = {
   headers?: any
   baseUrl?: string
   /**
-   * Keys in `defaults` are just friendly names. Defaults are based on the `id` and `value` passed
+   * Sets the default (placeholder) value of request data.
+   *
+   * @example {
+   *  // If you are not setting `ìd`
+   *  'GET /profile': dbUserProfile,
+   *  'GET /todos': [],
+   *
+   *  // If you are setting `id`:
+   *  'MyCustomId': { 'a': 'b' }
+   * }
    */
+  value?: {
+    [key: string]: any
+  }
   defaults?: {
     [key: string]: {
       /**

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -145,6 +145,18 @@ export function setParamsAndQuery(
   return setURLParams(setQueryParams(url, p.query), p.params)
 }
 
+export function actionResult<T>(
+  data: T,
+  config?: {
+    status?: number
+  }
+) {
+  return {
+    data,
+    ...config
+  }
+}
+
 /**
  * Creates a new request function. This is for usage with fetcher and fetcher.extend
  */


### PR DESCRIPTION
# Features

- ### Adds the `useServerMutation` hook:
The `useSeverMutation` hook works like the `useServerAction`  hook except it is not automatic.

- ### Default values can be passed in a simpler way in `<FetchConfig>`:

Before:

```tsx
<FetchConfig
  defaults={{
    "GET /some url": {
      id: "SomeId", // This is required if you have a custom id
      value: {
        a: "b",
      },
    },
  }}
>
  {children}
</FetchConfig>
```

After:

```tsx
<FetchConfig
  value={{
    SomeId: {
      a: "b",
    },
  }}
>
  {children}
</FetchConfig>
```

- ### Adds the `actionResult` helper

The `actionResult` function helps format an action's return value to have automatic type inference when using an action with the `useServerAction` and `useServerMutation` hooks. This is not mandatory.

Example:

```ts
// actiont.ts
"use server"

import { actionResult } from "http-react"

export async function getServerData({ id }: { id: number }) {
  const someData = await getData(id)

  return actionResult(someData, { status: 200 })

}
```
> The `{ status: 200 }` part is optional


Using the action:
```tsx
import { useServerAction } from "http-react"

import { getServerData } from "@/actions"

function useMyAction() {
  const { data } = useServerAction(getServerData, {
    params: {
      id: 1
    }
  })
}

```

> Both `data` and `params` have static typing infered from the action